### PR TITLE
Change to astropy units in stellib.py

### DIFF
--- a/beast/physicsmodel/stars/stellib.py
+++ b/beast/physicsmodel/stars/stellib.py
@@ -12,6 +12,7 @@ from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from scipy.interpolate import interp1d
 from numpy.lib import recfunctions
+from astropy import constants
 
 from ..grid import SpectralGrid
 from ..helpers import Path
@@ -22,9 +23,11 @@ from .include import __interp__
 from ...tools.pbar import Pbar
 from ...tools.helpers import nbytes
 
-lsun = 3.839e+26   # in W (Watts)
+#lsun = 3.839e+26   # in W (Watts)
+lsun = constants.L_sun
 sig_stefan = 5.67037321 * 1e-8  # W * m**-2 * K**-4
-rsun = 6.955e8  # in meters
+#rsun = 6.955e8  # in meters
+rsun = constants.R_sun
 
 config = {
     'basel_2.2_pegase': __ROOT__ + '/libs/BaSeL_v2.2.pegase.grid.fits',


### PR DESCRIPTION
I changed the constants for solar radius and solar luminosity to the astropy.constants format.